### PR TITLE
Add timezone back to ics functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ differently across the latitudes.
 
 Parameters like geographic location (longitude & latitude), timezone and the range of dates for which these events 
 should be created can be specified ad libitum. If you register this application in Google Cloud and grant read and write
-access to your personal Google calendar, the events can be inserted directly into your Google calendar using api calls.
+access to your personal Google Calendar, the events can be inserted directly into your Google Calendar using api calls.
 You specify the name of your target calendar and if it does not exist, it will be created for you.
 
 Alternatively you can use this application to create an ics file and import it to any calendar you like. In that case,
 registration/authentication are unnecessary.  
 
-While the api functionality is only of interest for users of Google calendar, the generated calendar ics file is 
+While the api functionality is only of interest for users of Google Calendar, the generated calendar ics file is 
 universal (conforms to this [standard](https://datatracker.ietf.org/doc/html/rfc5545#page-102)) and so it can be 
 imported to every calendar application. 
  
@@ -40,10 +40,10 @@ poetry install
 ```
 This will set up a virtual environment and install the application (including all dev and non-dev dependencies).
 
-## Use google calendar api to create calendar events
+## Use Google Calendar api to create calendar events
 
-To allow insertion of events into your Google calendar, the app has to be registered in Google cloud and access to the
-api enabled. The Google cloud console is also the place where you can create credentials (a file named "credentials.json").
+To allow insertion of events into your Google Calendar, the app has to be registered in Google Cloud and access to the
+api enabled. The Google Cloud console is also the place where you can create credentials (a file named "credentials.json").
 When you run the application for the first time, the authentication flow will lead to the creation of access tokens (the
 credentials are required in this process!). All details of the process are outlined 
 [here](https://developers.google.com/calendar/quickstart/python). 
@@ -62,7 +62,7 @@ Example for a complete set of options:
 poetry run suncal api --cal Sonne --from 2023-6-10 --to 2023-6-10 --event sunrise --timezone 'Europe/Berlin' \
 --long 14.32 --lat 52
 ```
-The command above will create only one entry in a Google calendar named "Sonne" - for the sunrise on 6.10.2023.
+The command above will create only one entry in a Google Calendar named "Sonne" - for the sunrise on 6.10.2023.
 
 or for Redwood City:
 
@@ -74,7 +74,7 @@ The command above creates sunrise events for the whole year 2023.
 
 ## Export events to ics file
 
-If you want to export the sun calendar to an ics file, registration of this app in Google cloud is unnecessary.
+If you want to export the sun calendar to an ics file, registration of this app in Google Cloud is unnecessary.
 You can provide a name for the ics file, but if you don't, the name will be created automatically. You can see a
 description of all command line options with:
 
@@ -107,7 +107,7 @@ you also add a corresponding test.
 Our calculations of sun and moon events are based on [skyfield](https://rhodesmill.org/skyfield/).
 
 ## google-api-python-client, google-auth-oauthlib, google
-Tools for communication with the Google api and authentication flow.
+Tools for communication with the Google API and authentication flow.
 
 ## pydantic
 Data validation and settings management using python type annotations.

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ We are using the standard symbols for those phases, although we are aware that t
 differently across the latitudes.
 
 Parameters like geographic location (longitude & latitude), timezone and the range of dates for which these events 
-should be created can be specified ad libitum. If you register this application in google cloud and grant read and write
-access to your personal google calendar, the events can be inserted directly into your google calendar using api calls.
+should be created can be specified ad libitum. If you register this application in Google Cloud and grant read and write
+access to your personal Google calendar, the events can be inserted directly into your Google calendar using api calls.
 You specify the name of your target calendar and if it does not exist, it will be created for you.
 
 Alternatively you can use this application to create an ics file and import it to any calendar you like. In that case,
 registration/authentication are unnecessary.  
 
-While the api functionality is only of interest for users of google calendar, the generated calendar ics file is 
+While the api functionality is only of interest for users of Google calendar, the generated calendar ics file is 
 universal (conforms to this [standard](https://datatracker.ietf.org/doc/html/rfc5545#page-102)) and so it can be 
 imported to every calendar application. 
  
@@ -42,8 +42,8 @@ This will set up a virtual environment and install the application (including al
 
 ## Use google calendar api to create calendar events
 
-To allow insertion of events into your google calendar, the app has to be registered in google cloud and access to the
-api enabled. The google cloud console is also the place where you can create credentials (a file named "credentials.json").
+To allow insertion of events into your Google calendar, the app has to be registered in Google cloud and access to the
+api enabled. The Google cloud console is also the place where you can create credentials (a file named "credentials.json").
 When you run the application for the first time, the authentication flow will lead to the creation of access tokens (the
 credentials are required in this process!). All details of the process are outlined 
 [here](https://developers.google.com/calendar/quickstart/python). 
@@ -62,7 +62,7 @@ Example for a complete set of options:
 poetry run suncal api --cal Sonne --from 2023-6-10 --to 2023-6-10 --event sunrise --timezone 'Europe/Berlin' \
 --long 14.32 --lat 52
 ```
-The command above will create only one entry in a google calendar named "Sonne" - for the sunrise on 6.10.2023.
+The command above will create only one entry in a Google calendar named "Sonne" - for the sunrise on 6.10.2023.
 
 or for Redwood City:
 
@@ -74,7 +74,7 @@ The command above creates sunrise events for the whole year 2023.
 
 ## Export events to ics file
 
-If you want to export the sun calendar to an ics file, registration of this app in google cloud is unnecessary.
+If you want to export the sun calendar to an ics file, registration of this app in Google cloud is unnecessary.
 You can provide a name for the ics file, but if you don't, the name will be created automatically. You can see a
 description of all command line options with:
 
@@ -85,7 +85,7 @@ poetry run suncal ics --help
 Example:
 
 ```bash
-poetry run suncal ics --from 2021-6-10 --to 2021-6-10 --event sunrise \
+poetry run suncal ics --from 2021-6-10 --to 2021-6-10 --event sunrise --timezone 'Europe/Berlin' \
 --long 14.32 --lat 52 --filename myIcsFile.ics
 ```
 
@@ -107,7 +107,7 @@ you also add a corresponding test.
 Our calculations of sun and moon events are based on [skyfield](https://rhodesmill.org/skyfield/).
 
 ## google-api-python-client, google-auth-oauthlib, google
-Tools for communication with the google api and authentication flow.
+Tools for communication with the Google api and authentication flow.
 
 ## pydantic
 Data validation and settings management using python type annotations.

--- a/suncal/cli.py
+++ b/suncal/cli.py
@@ -99,6 +99,14 @@ def common_suncal_options(function: Callable) -> Callable:
         required=True,
     )(function)
 
+    function = click.option(
+        "--timezone",
+        "timezone",
+        type=IANATimeZoneString(),
+        help="Timezone of the target calendar. IANA timezone string. Case-insensitive matching enabled.",
+        required=True,
+    )(function)
+
     function = click.option('--dev/--no-dev', 'dev_mode', default=False)(
         function
     )

--- a/suncal/cli.py
+++ b/suncal/cli.py
@@ -103,7 +103,7 @@ def common_suncal_options(function: Callable) -> Callable:
         "--timezone",
         "timezone",
         type=IANATimeZoneString(),
-        help="Timezone of the target calendar. IANA timezone string. Case-insensitive matching enabled.",
+        help="Timezone of the user location. IANA timezone string. Case-insensitive matching enabled.",
         required=True,
     )(function)
 

--- a/suncal/suncal.py
+++ b/suncal/suncal.py
@@ -5,7 +5,6 @@ from typing import Optional
 import click
 
 from suncal.auth import get_credentials
-from suncal.cli import IANATimeZoneString
 from suncal.cli import common_suncal_options
 from suncal.fileio import export_events_to_ics
 from suncal.models.astro import CALC
@@ -49,15 +48,13 @@ def suncal_main(
     event_name: str,
     longitude: float,
     latitude: float,
+    timezone: str,
     return_val: str,
     filename: Optional[str] = None,
     calendar_title: Optional[str] = None,
-    timezone: Optional[str] = None,
 ) -> None:
 
     assert to_date >= from_date, "to_date must be >= from_date."
-    # for ics files the timezone is not required, so we use UTC for all internal calculations
-    timezone = timezone or "UTC"
 
     location = Location(
         timezone=timezone, longitude=longitude, latitude=latitude
@@ -110,12 +107,6 @@ def suncal():
     type=click.STRING,
     required=True,
     help="Google calendar name.",
-)
-@click.option(
-    "--timezone",
-    type=IANATimeZoneString(),
-    help="Default timezone of google calendar. IANA timezone string. Case-insensitive matching enabled.",
-    required=True,
 )
 def api(
     dev_mode: bool,
@@ -171,6 +162,7 @@ def ics(
     event_name: str,
     longitude: float,
     latitude: float,
+    timezone: str,
     filename: Optional[str] = None,
 ) -> None:
     """Calculate sunrise/sunset/moonrise/moonset/moonphase for provided range of datesand export them to ics file."""
@@ -183,6 +175,7 @@ def ics(
             latitude=latitude,
             return_val="ics",
             filename=filename,
+            timezone=timezone,
         )
     else:
         # print all parsed arguments to the console (as dict)
@@ -194,4 +187,5 @@ def ics(
             longitude=longitude,
             latitude=latitude,
             filename=filename,
+            timezone=timezone,
         )


### PR DESCRIPTION
Addressing issue https://github.com/rotkehlxen/suncal/issues/57
PS: because of the missing timezone information (and automatic use of UTC) we also got the wrong event time in the calendar event summary (when the calendar was imported from the ics file generated by this app):
<img width="354" alt="Screenshot 2023-03-15 at 18 28 57" src="https://user-images.githubusercontent.com/44971491/225410257-ab107858-5f75-4a7b-9d85-6f86bf6f455b.png">
This is now also fixed!
## Testing
Integration tests pass.