### PR TITLE
Timezone from GPS coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ poetry run suncal ics --help
 Example:
 
 ```bash
-poetry run suncal ics --from 2021-6-10 --to 2021-6-10 --event sunrise --long 14.32 --lat 52 --filename myIcsFile.ics
+poetry run suncal ics --from 2021-6-10 --to 2021-6-10 --event sunrise --long 14.32 --lat 52 \ 
+--filename myIcsFile.ics
 ```
 
 The file name is an optional argument: if you don't provide a name, it will be generated from the name of the event and

--- a/README.md
+++ b/README.md
@@ -69,16 +69,20 @@ to see a description of all command line options.
 Example for a complete set of options:
 
 ```bash
-poetry run suncal api --cal Sonne --from 2023-6-10 --to 2023-6-10 --event sunrise --long 14.32 --lat 52
+poetry run suncal api --cal Sonne --from 2023-6-10 --to 2023-6-10 --event sunrise \
+ --long 14.32 --lat 52
 ```
-The command above will create only one entry in a Google Calendar named "Sonne" - for the sunrise on 6.10.2023.
-You have to specify the name of your target calendar (`--cal Sonne` in the command above) **but** if a calendar with 
-that name does not exist, it will be created for you.
+The command above will create only one event in a Google Calendar named "Sonne" - for the sunrise on 6.10.2023 in 
+Berlin/Germany.
 
-Another example for Redwood City:
+Note: you have to specify the name of your target calendar (`--cal Sonne` in the example above) **but** if a calendar 
+with that name does not exist, it will be created for you automatically.
+
+Another example for Redwood City in California:
 
 ```bash
-poetry run suncal api --cal Sonnenaufgang --from 2023-1-01 --to 2023-12-31 --event sunrise --long -122.2281 --lat 37.4848
+poetry run suncal api --cal Sonnenaufgang --from 2023-1-01 --to 2023-12-31 --event sunrise \ 
+--long -122.2281 --lat 37.4848
 ```
 The command above creates sunrise events for the whole year 2023.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 - [What suncal can do for you](https://github.com/rotkehlxen/suncal#what-does-suncal-do-%EF%B8%8F)
   - [Supported Events](https://github.com/rotkehlxen/suncal#supported-events)
-- [Initial Setup](https://github.com/rotkehlxen/suncal#initial-setup)
+- [Install and run Suncal](https://github.com/rotkehlxen/suncal#install-and-run-suncal)
   - [Export events to Google Calendar](https://github.com/rotkehlxen/suncal#use-google-calendar-api-to-create-calendar-events)
   - [Export events to ics file](https://github.com/rotkehlxen/suncal#export-events-to-an-ics-file)
 - [Rules for collaborators](https://github.com/rotkehlxen/suncal#rules-for-collaborators)
@@ -43,7 +43,7 @@ We are using standard symbols for those phases, although we are aware that the p
 differently across the latitudes. Suncal creates an all-day event for each phase but the event description contains the 
 precise time at which this phase can be observed.
 
-# Initial setup
+# Install and run Suncal
 
 The application was built with [poetry](https://python-poetry.org/) and depends on python 3.11.2, so make sure you have 
 *poetry* and any minor version of python 3.11 installed on your system. The package will probably work with any python 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Would you like to know when the sun rises next week on Tue and have an entry in your calendar for this event without any 
 manual effort and 100% for free? Then suncal is the right tool for you!
 
-You can use this command line tool to either generate a calendar 
-[standard](https://datatracker.ietf.org/doc/html/rfc5545#page-102) ics file which you can import into any calendar
+You can use this command line tool to either generate a 
+[standard ics](https://datatracker.ietf.org/doc/html/rfc5545#page-102) file which you can import into any calendar
 application you like or you can have suncal create events in your Google calendar directly (via calls to the Google
 calendar API).
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+- [What suncal can do for you](https://github.com/rotkehlxen/suncal#what-does-suncal-do-%EF%B8%8F)
+  - [Supported Events](https://github.com/rotkehlxen/suncal#supported-events)
+- [Initial Setup](https://github.com/rotkehlxen/suncal#initial-setup)
+  - [Export events to Google Calendar](https://github.com/rotkehlxen/suncal#use-google-calendar-api-to-create-calendar-events)
+  - [Export events to ics file](https://github.com/rotkehlxen/suncal#export-events-to-an-ics-file)
+- [Rules for collaborators](https://github.com/rotkehlxen/suncal#rules-for-collaborators)
+
+
 # What suncal can do for you 🌞❤️🌜
 Would you like to know when the sun rises next week on Tue and have an entry in your calendar for this event without any 
 manual effort and 100% for free? Then suncal is the right tool for you!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,28 @@
-# What does suncal do? 🌞❤️🌜
+# What suncal can do for you 🌞❤️🌜
+Would you like to know when the sun rises next week on Tue and have an entry in your calendar for this event without any 
+manual effort and 100% for free? Then suncal is the right tool for you!
 
-Suncal creates a sun (and moon) calendar. You can choose between the following events: sunrise, sunset, moonrise,  
-moonset and moonphase. We currently support these moon phases:
+You can use this command line tool to either generate a calendar 
+[standard](https://datatracker.ietf.org/doc/html/rfc5545#page-102) ics file which you can import into any calendar
+application you like or you can have suncal create events in your Google calendar directly (via calls to the Google
+calendar API).
+
+To create these events you need to specify the geographic location (longitude & latitude) and a range of dates. 
+Suncal will determine the timezone of the location automatically.
+
+## Supported Events
+
+### 1 Sunrise and Sunset
+### 2 Golden Hour and Blue Hour
+
+The Golden Hour is a period of time around sunrise/sunset, i.e. where the center of the sun is between -4 and 6 degrees 
+above the horizon. The Blue Hour is a period before sunrise/after sunset where the natural light is infused by a lot of 
+blue tones. We define it as the period in which the center of the sun is between 8 and 4 degrees below the horizon. 
+The Golden/Blue Hour actually varies a lot in length depending on location. You can create the corresponding calendar 
+events by using the event names 'golden_hour_morning', 'golden_hour_evening', 'blue_hour_morning' or 'blue_hour_evening'. 
+
+### 3 Moonrise and Moonset
+### 4 The Moon Phases
 
 |     phase     | symbol in calendar |
 |:-------------:|:------------------:|
@@ -10,42 +31,24 @@ moonset and moonphase. We currently support these moon phases:
 |   Full Moon   |         🌝         |
 | Last Quarter  |         🌗         |
 
-We are using the standard symbols for those phases, although we are aware that the partially lit moon appears 
-differently across the latitudes.
+We are using standard symbols for those phases, although we are aware that the partially lit moon appears 
+differently across the latitudes. Suncal creates an all-day event for each phase but the event description contains the 
+precise time at which this phase can be observed.
 
-You can also calculate the **Golden** and **Blue Hour** which might be of particular interest for photographers. 
-The Golden Hour is a period of time around sunrise/sunset, i.e. where the center of the sun is between -4 and 6 degrees 
-above the horizon. The Blue Hour is a period before sunrise/after sunset where the natural light is infused by a lot of 
-blue tones. We define it as the period in which the center of the sun is between 8 and 4 degrees below the horizon. 
-The Golden/Blue Hour actually varies a lot in length depending on location. You can create the corresponding calendar 
-events by using the event names 'golden_hour_morning', 'golden_hour_evening', 'blue_hour_morning' or 'blue_hour_evening'. 
-
-Parameters like geographic location (longitude & latitude), timezone and the range of dates for which these events 
-should be created can be specified ad libitum. If you register this application in Google Cloud and grant read and write
-access to your personal Google Calendar, the events can be inserted directly into your Google Calendar using api calls.
-You specify the name of your target calendar and if it does not exist, it will be created for you.
-
-Alternatively you can use this application to create an ics file and import it to any calendar you like. In that case,
-registration/authentication are unnecessary.  
-
-While the api functionality is only of interest for users of Google Calendar, the generated calendar ics file is 
-universal (conforms to this [standard](https://datatracker.ietf.org/doc/html/rfc5545#page-102)) and so it can be 
-imported to every calendar application. 
- 
-# How to run suncal
+# Initial setup
 
 The application was built with [poetry](https://python-poetry.org/) and depends on python 3.11.2, so make sure you have 
-poetry and any minor version of python 3.11 installed on your system (to manage several installations of python we recommend 
-using [pyenv](https://github.com/pyenv/pyenv)). The package will probably work with any python version 3.9 and above, 
-but we are only testing in 3.11. The poetry version we tested with is 1.3.2, and we know that older versions 
-(1.1.3 and 1.1.4) do not correctly install the dev tool dependencies despite resolving them correctly. 
+*poetry* and any minor version of python 3.11 installed on your system. The package will probably work with any python 
+version 3.9 and above but we are only testing in 3.11. The poetry version we tested with is 1.3.2, and we know that 
+older versions (1.1.3 and 1.1.4) do not correctly install the dev tool dependencies despite resolving them correctly. 
 
 Clone this repository, cd to the repository and run
 
 ```bash
 poetry install
 ```
-This will set up a virtual environment and install the application (including all dev and non-dev dependencies).
+This will set up a virtual environment and install the command line application 
+(including all dev and non-dev dependencies).
 
 ## Use Google Calendar api to create calendar events
 
@@ -66,20 +69,20 @@ to see a description of all command line options.
 Example for a complete set of options:
 
 ```bash
-poetry run suncal api --cal Sonne --from 2023-6-10 --to 2023-6-10 --event sunrise --timezone 'Europe/Berlin' \
---long 14.32 --lat 52
+poetry run suncal api --cal Sonne --from 2023-6-10 --to 2023-6-10 --event sunrise --long 14.32 --lat 52
 ```
 The command above will create only one entry in a Google Calendar named "Sonne" - for the sunrise on 6.10.2023.
+You have to specify the name of your target calendar (`--cal Sonne` in the command above) **but** if a calendar with 
+that name does not exist, it will be created for you.
 
-or for Redwood City:
+Another example for Redwood City:
 
 ```bash
-poetry run suncal api --cal Sonnenaufgang --from 2023-1-01 --to 2023-12-31 --event sunrise --timezone 'US/Pacific' \
---long -122.2281 --lat 37.4848
+poetry run suncal api --cal Sonnenaufgang --from 2023-1-01 --to 2023-12-31 --event sunrise --long -122.2281 --lat 37.4848
 ```
 The command above creates sunrise events for the whole year 2023.
 
-## Export events to ics file
+## Export events to an ics file
 
 If you want to export the sun calendar to an ics file, registration of this app in Google Cloud is unnecessary.
 You can provide a name for the ics file, but if you don't, the name will be created automatically. You can see a
@@ -92,9 +95,11 @@ poetry run suncal ics --help
 Example:
 
 ```bash
-poetry run suncal ics --from 2021-6-10 --to 2021-6-10 --event sunrise --timezone 'Europe/Berlin' \
---long 14.32 --lat 52 --filename myIcsFile.ics
+poetry run suncal ics --from 2021-6-10 --to 2021-6-10 --event sunrise --long 14.32 --lat 52 --filename myIcsFile.ics
 ```
+
+The file name is an optional argument: if you don't provide a name, it will be generated from the name of the event and
+the current timestamp. 
 
 # Rules for collaborators
 
@@ -105,8 +110,7 @@ create a new branch and make sure to run all checks before setting up your PR: c
 ./qa/pychecks.sh
 ```
 
-If any of the checks fail, the PR will not be accepted. If you add a function/class, 
-you also add a corresponding test.
+If any of the checks fail, the PR will not be accepted. If you add a function/class, you also add a corresponding test.
 
 # Main Dependencies
 
@@ -116,9 +120,6 @@ Our calculations of sun and moon events are based on [skyfield](https://rhodesmi
 ## google-api-python-client, google-auth-oauthlib, google
 Tools for communication with the Google API and authentication flow.
 
-## pydantic
-Data validation and settings management using python type annotations.
-Pydantic enforces type hints at runtime. Ideal for exchanging data with APIs.
-
-## Dev dependencies
-For a comprehensive list check the pyproject.toml.
+## timezonefinder
+We use [timezonefinder](https://github.com/jannikmi/timezonefinder) to determine the timezone from the GPS coordinates
+provided by the user.

--- a/poetry.lock
+++ b/poetry.lock
@@ -271,7 +271,7 @@ files = [
 name = "cffi"
 version = "1.15.1"
 description = "Foreign Function Interface for Python calling C code."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 files = [
@@ -702,6 +702,59 @@ protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.1 || >4.21.1,<4
 
 [package.extras]
 grpc = ["grpcio (>=1.44.0,<2.0.0dev)"]
+
+[[package]]
+name = "h3"
+version = "3.7.6"
+description = "Hierarchical hexagonal geospatial indexing system"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "h3-3.7.6-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:cd4a5103a86a7d98cffa3be77eb82080aa2e9d676bbd1661f3db9ecad7a4ef2b"},
+    {file = "h3-3.7.6-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:231959dceb4cc4ae86fe4fe2c385b176ed81712549e787b889dfa66f583676df"},
+    {file = "h3-3.7.6-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:b9de9da755c90bbc90d6c041396a20c91816cd86a0bafa3b8899681cfdc2c4c6"},
+    {file = "h3-3.7.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cda9a427b0de0d4069115ec765118888f180d0db915b5bc0dba52f5ae957b789"},
+    {file = "h3-3.7.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8bf1e080b9a47774754834e7f10155f3d2e3542bf895488a0519b2ae7d5b15db"},
+    {file = "h3-3.7.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d3b93e3f38eb6c8fc5051d1b289b74614fb5f2415d272fea18085dea260d6b0"},
+    {file = "h3-3.7.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:783b2ca4448360c5a184fd43b84fc5554e3a8fd02738ff31349506189c5b4b49"},
+    {file = "h3-3.7.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3bae8b95f21f20f04141a35f15c8caa74f2046eb01ef49e35fc45e6a8edfc8df"},
+    {file = "h3-3.7.6-cp310-cp310-win_amd64.whl", hash = "sha256:6ca9dd410e250d37f24a87c4ecb0615bb6d44a3f90eb5dbbf1b5e3d4489b8703"},
+    {file = "h3-3.7.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:991ee991f2ae41f629feb1cd32fa677b8512c72696eb0ad94fcf359d61184b2e"},
+    {file = "h3-3.7.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fcbfff87d223279f8e38bbee3ebf52b1b96ae280e9e7de24674d3c284373d946"},
+    {file = "h3-3.7.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eddf10d1d2139b3ea3ad1618c2074e1c47d3d36bddb5359e4955f5fd0b089d93"},
+    {file = "h3-3.7.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76abc02f14a8df42fb5d80e6045023fb756c49d3cb08d69a8ceb9362b95d4bec"},
+    {file = "h3-3.7.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc8030968586a7810aa192397ad9a4f7d7a963f57c9b3e210fc38de0aa5c2533"},
+    {file = "h3-3.7.6-cp311-cp311-win_amd64.whl", hash = "sha256:1bdc790d91138e781973dcaade5231db7fe8a876330939e0903f602acc4fb64c"},
+    {file = "h3-3.7.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:198718ab20a06ebe52f0aaafc02469e4a51964e5ba7990c3cc1d2fc32e7a54d9"},
+    {file = "h3-3.7.6-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02faa911f2d8425c641a1f7c08f3dc9c10a5a3d81408832afa40748534b999c8"},
+    {file = "h3-3.7.6-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b4db92ceaeb9a51cc875c302cdc5e1aa27eed776d95943ee55c941bc2f219a3"},
+    {file = "h3-3.7.6-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:4810ddb3d91411a6cbf87a28108fe31712f618ef223c349e1f6675602af2c473"},
+    {file = "h3-3.7.6-cp36-cp36m-win_amd64.whl", hash = "sha256:211ef3317dcf7863e2d01a97ab6da319b8451d78cd1633dd28faaf69e66bc321"},
+    {file = "h3-3.7.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:99b81620608378fc9910a5c630b0f17eb939156fa13e1adc55229d31f8c3f5ca"},
+    {file = "h3-3.7.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26f3175bd3ea3ee528dbf49308e7215a58351ce425e1c3a9838ae22526663311"},
+    {file = "h3-3.7.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d7b69015f5bab2525914fad370b96dc386437e19a14cfed3eb13868589263db"},
+    {file = "h3-3.7.6-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d0c2890fa10fa8695c020569c8d55da79e2c552a39533de4ae6991c7acb122e1"},
+    {file = "h3-3.7.6-cp37-cp37m-win_amd64.whl", hash = "sha256:1cd4f07c49721023c5fef401a4de03c47000705dfd116579dc6b61cad821305d"},
+    {file = "h3-3.7.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f8d1db3dcd8f6ce7f54e061e6c9fbecbb5c3978b9e54e44af05a53787c4f99b3"},
+    {file = "h3-3.7.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:495e37b1dee0ec46ccd88b278e571234b0d0d30648f161799d65a8d7f390b3f2"},
+    {file = "h3-3.7.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2e2c4808b7691b176c89ebf23c173b3b23dd4ce42f8f494b32c6e31ceee49af"},
+    {file = "h3-3.7.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b58b1298bf1068704c6d9426749c8ae6021b53d982d5153cc4161c7042ecd810"},
+    {file = "h3-3.7.6-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a2872f695168c4700c73edd6eab9c6181387d7ea177de13b130ae61e613ff7de"},
+    {file = "h3-3.7.6-cp38-cp38-win_amd64.whl", hash = "sha256:98c3951c3b67ca3de06ef70aa74a9752640a3eca9b4d68e0d5d8e4fc6fa72337"},
+    {file = "h3-3.7.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0724d4645c1da59e02b3305050c52b93ce1d8971d1d139433d464fcc103249a6"},
+    {file = "h3-3.7.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e1f6ec0f2246381ce3a7f72da1ce825a5474eb7c8fb25a2ea1f16c6606ce34a7"},
+    {file = "h3-3.7.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1471ff4d3875b25b521eeec5c2b72abe27b8e6af10ab99b7da5c0de545b0e832"},
+    {file = "h3-3.7.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb96f2caae519d0ed17acde625af528476dca121b0336d3eb776429d40284ef6"},
+    {file = "h3-3.7.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b1b1bce0dee05175f8d422e50ffa1afacb9a7e78ae0963059aebfbef50e10175"},
+    {file = "h3-3.7.6-cp39-cp39-win_amd64.whl", hash = "sha256:36ea935833c37fdfd7ffbfc000d7cd20addcdf67f30b26a6b9bccb9210b03704"},
+    {file = "h3-3.7.6.tar.gz", hash = "sha256:9bbd3dbac99532fa521d7d2e288ff55877bea3223b070f659ed7b5f8f1f213eb"},
+]
+
+[package.extras]
+all = ["flake8", "numpy", "pylint", "pytest", "pytest-cov"]
+numpy = ["numpy"]
+test = ["flake8", "pylint", "pytest", "pytest-cov"]
 
 [[package]]
 name = "httplib2"
@@ -1820,7 +1873,7 @@ pyasn1 = ">=0.4.6,<0.5.0"
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
@@ -2391,6 +2444,23 @@ objc = ["pyobjc-framework-Cocoa"]
 win32 = ["pywin32"]
 
 [[package]]
+name = "setuptools"
+version = "67.6.1"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools-67.6.1-py3-none-any.whl", hash = "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"},
+    {file = "setuptools-67.6.1.tar.gz", hash = "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "sgp4"
 version = "2.21"
 description = "Track Earth satellites given TLE data, using up-to-date 2020 SGP4 routines."
@@ -2541,6 +2611,28 @@ tornado = ">=6.1.0"
 [package.extras]
 docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["pre-commit", "pytest (>=7.0)", "pytest-timeout"]
+
+[[package]]
+name = "timezonefinder"
+version = "6.2.0"
+description = "fast python package for finding the timezone of any point on earth (coordinates) offline"
+category = "main"
+optional = false
+python-versions = ">=3.8,<4"
+files = [
+    {file = "timezonefinder-6.2.0-cp38-cp38-manylinux_2_35_x86_64.whl", hash = "sha256:06aa5926ed31687ea9eb00ab53203631f09a78f307285b4929da4ac4e2889240"},
+    {file = "timezonefinder-6.2.0.tar.gz", hash = "sha256:d41fd2650bb4221fae5a61f9c2767158f9727c4aaca95e24da86394feb704220"},
+]
+
+[package.dependencies]
+cffi = ">=1.15.1,<2"
+h3 = ">=3.7.6,<4"
+numpy = ">=1.18,<2"
+setuptools = ">=65.5"
+
+[package.extras]
+numba = ["numba (>=0.56,<1)"]
+pytz = ["pytz (>=2022.7.1)"]
 
 [[package]]
 name = "tinycss2"
@@ -2843,4 +2935,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11.2"
-content-hash = "a2f19701983c0e480912ef8e59eb01d7f0d61ffbd277cc1eefff06043b54213f"
+content-hash = "02add0c0180bdcad33d42e0ecd641e61ef247ea59c94257d1d4350810f6c383d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ click = "^8.0.1"
 google = "^3.0.0"
 pytz = "^2022.7.1"
 skyfield = "^1.45"
+timezonefinder = "^6.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.1"

--- a/suncal/cli.py
+++ b/suncal/cli.py
@@ -102,8 +102,9 @@ def common_suncal_options(function: Callable) -> Callable:
         "--timezone",
         "timezone",
         type=IANATimeZoneString(),
-        help="Timezone of the user location. IANA timezone string. Case-insensitive matching enabled.",
-        required=True,
+        help="IANA timezone string. Only provide this argument if you want to override the timezone which is set "
+             "according to your GPS coordinates automatically. Case-insensitive matching enabled.",
+        required=False,
     )(function)
 
     function = click.option('--dev/--no-dev', 'dev_mode', default=False)(

--- a/suncal/cli.py
+++ b/suncal/cli.py
@@ -103,7 +103,7 @@ def common_suncal_options(function: Callable) -> Callable:
         "timezone",
         type=IANATimeZoneString(),
         help="IANA timezone string. Only provide this argument if you want to override the timezone which is set "
-             "according to your GPS coordinates automatically. Case-insensitive matching enabled.",
+        "according to your GPS coordinates automatically. Case-insensitive matching enabled.",
         required=False,
     )(function)
 

--- a/suncal/suncal.py
+++ b/suncal/suncal.py
@@ -1,6 +1,7 @@
 import datetime as dt
 from typing import List
 from typing import Optional
+from timezonefinder import TimezoneFinder
 
 import click
 
@@ -48,14 +49,16 @@ def suncal_main(
     event_name: str,
     longitude: float,
     latitude: float,
-    timezone: str,
     return_val: str,
+    timezone: Optional[str] = None,
     filename: Optional[str] = None,
     calendar_title: Optional[str] = None,
 ) -> None:
 
     assert to_date >= from_date, "to_date must be >= from_date."
 
+    tf = TimezoneFinder()
+    timezone = timezone or tf.timezone_at(lng=longitude, lat=latitude)
     location = Location(
         timezone=timezone, longitude=longitude, latitude=latitude
     )

--- a/suncal/suncal.py
+++ b/suncal/suncal.py
@@ -91,7 +91,7 @@ def suncal_main(
 
     else:
         click.echo(
-            f"*** {event_name.title()} could not be calculated for the specified location. "
+            f"*** {event_name.title()} could not be calculated for the specified location on any of the provided dates."
             f"No calendar events created. ***"
         )
 

--- a/suncal/suncal.py
+++ b/suncal/suncal.py
@@ -1,9 +1,9 @@
 import datetime as dt
 from typing import List
 from typing import Optional
-from timezonefinder import TimezoneFinder
 
 import click
+from timezonefinder import TimezoneFinder
 
 from suncal.auth import get_credentials
 from suncal.cli import common_suncal_options
@@ -71,6 +71,7 @@ def suncal_main(
 
         if return_val == "api":
             assert calendar_title is not None
+            assert timezone is not None
 
             # refresh access tokens or create them if they do not exist (authentication flow)
             credentials = get_credentials(SCOPES)

--- a/tests/test_astro.py
+++ b/tests/test_astro.py
@@ -11,6 +11,7 @@ from suncal.models.astro import MoonPhase
 from suncal.models.astro import RiseSet
 from suncal.models.astro import calculate_moon_phase
 from suncal.utils import tz_aware_dt
+from tests.test_data import CITIES
 
 
 def test_location_class():
@@ -87,59 +88,7 @@ def test_rise_set_calculations():
     date = dt.date(2023, 3, 9)
     prec = dt.timedelta(minutes=3)
 
-    # locations, date 9.3.2023, sun/moon rise & set according to timeanddate.com (tad) in local time
-    berlin = {
-        'lat': 52.520008,
-        'long': 13.404954,
-        'timezone': 'Europe/Berlin',
-        'sunrise': dt.time(6, 35),
-        'sunset': dt.time(17, 59),
-        'moonrise': dt.time(20, 17),
-        'moonset': dt.time(7, 26),
-    }
-
-    redwoodcity = {
-        'lat': 37.4848,
-        'long': -122.2281,
-        'timezone': 'US/Pacific',
-        'sunrise': dt.time(6, 28),
-        'sunset': dt.time(18, 10),
-        'moonrise': dt.time(20, 33),
-        'moonset': dt.time(7, 40),
-    }
-
-    punta_arenas = {
-        'lat': -53.163833,
-        'long': -70.917068,
-        'timezone': 'America/Santiago',
-        'sunrise': dt.time(7, 24),
-        'sunset': dt.time(20, 22),
-        'moonrise': dt.time(21, 12),
-        'moonset': dt.time(9, 33),
-    }
-    maputo = {
-        'lat': -25.966667,
-        'long': 32.583333,
-        'timezone': 'Africa/Johannesburg',
-        'sunrise': dt.time(5, 47),
-        'sunset': dt.time(18, 12),
-        'moonrise': dt.time(19, 28),
-        'moonset': dt.time(7, 15),
-    }
-
-    auckland = {
-        'lat': -36.848461,
-        'long': 174.763336,
-        'timezone': 'Pacific/Auckland',
-        'sunrise': dt.time(7, 13),
-        'sunset': dt.time(19, 49),
-        'moonrise': dt.time(20, 46),
-        'moonset': dt.time(8, 23),
-    }
-
-    cities = [berlin, redwoodcity, punta_arenas, maputo, auckland]
-
-    for city in cities:
+    for city in CITIES:
         location = Location(
             timezone=city['timezone'],
             longitude=city['long'],

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,53 @@
+import datetime as dt
+
+# locations, date 9.3.2023, sun/moon rise & set according to timeanddate.com (tad) in local time
+berlin = {
+    'lat': 52.520008,
+    'long': 13.404954,
+    'timezone': 'Europe/Berlin',
+    'sunrise': dt.time(6, 35),
+    'sunset': dt.time(17, 59),
+    'moonrise': dt.time(20, 17),
+    'moonset': dt.time(7, 26),
+}
+
+redwoodcity = {
+    'lat': 37.4848,
+    'long': -122.2281,
+    'timezone': 'America/Los_Angeles',
+    'sunrise': dt.time(6, 28),
+    'sunset': dt.time(18, 10),
+    'moonrise': dt.time(20, 33),
+    'moonset': dt.time(7, 40),
+}
+
+punta_arenas = {
+    'lat': -53.163833,
+    'long': -70.917068,
+    'timezone': 'America/Punta_Arenas',
+    'sunrise': dt.time(7, 24),
+    'sunset': dt.time(20, 22),
+    'moonrise': dt.time(21, 12),
+    'moonset': dt.time(9, 33),
+}
+maputo = {
+    'lat': -25.966667,
+    'long': 32.583333,
+    'timezone': 'Africa/Maputo',
+    'sunrise': dt.time(5, 47),
+    'sunset': dt.time(18, 12),
+    'moonrise': dt.time(19, 28),
+    'moonset': dt.time(7, 15),
+}
+
+auckland = {
+    'lat': -36.848461,
+    'long': 174.763336,
+    'timezone': 'Pacific/Auckland',
+    'sunrise': dt.time(7, 13),
+    'sunset': dt.time(19, 49),
+    'moonrise': dt.time(20, 46),
+    'moonset': dt.time(8, 23),
+}
+
+CITIES = [berlin, redwoodcity, punta_arenas, maputo, auckland]

--- a/tests/test_timezonefinder.py
+++ b/tests/test_timezonefinder.py
@@ -1,0 +1,11 @@
+from timezonefinder import TimezoneFinder
+from tests.test_data import CITIES
+
+def test_timezonefinder():
+    tf = TimezoneFinder()
+
+    for city in CITIES:
+        assert tf.timezone_at(lng = city['long'], lat = city['lat']) == city['timezone']
+
+    # test a small town, Zahna
+    assert tf.timezone_at(lng=12.785, lat=51.916) == 'Europe/Berlin'

--- a/tests/test_timezonefinder.py
+++ b/tests/test_timezonefinder.py
@@ -1,11 +1,13 @@
 from timezonefinder import TimezoneFinder
+
 from tests.test_data import CITIES
+
 
 def test_timezonefinder():
     tf = TimezoneFinder()
 
     for city in CITIES:
-        assert tf.timezone_at(lng = city['long'], lat = city['lat']) == city['timezone']
+        assert tf.timezone_at(lng=city['long'], lat=city['lat']) == city['timezone']  # type: ignore
 
     # test a small town, Zahna
     assert tf.timezone_at(lng=12.785, lat=51.916) == 'Europe/Berlin'


### PR DESCRIPTION
Addressing issue #45.
Timezone is now an optional argument. If the user does not provide a timezone, it's derived from the GPS coordinates. If the user does provide a timezone, it will override the calculated default (for the "advanced" user). 

I assume that error handling won't be necessary, because our command line tool validates longitude and latitude. If longitude and latitude are valid, mapping a timezone should always be possible. 

PS: I also reorganised the Readme.